### PR TITLE
Update gast to version 0.5.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "gast" %}
-{% set version = "0.5.1" %}
-{% set sha256 = "b00e63584db482ffe6107b5832042bbe5c5bf856e3c7279b6e93201b3dcfcb46" %}
+{% set version = "0.5.2" %}
+{% set sha256 = "f81fcefa8b982624a31c9e4ec7761325a88a0eba60d36d1da90e47f8fe3c67f7" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
1. check the upstream
2. check the pinnings
    the pinnings are up to date
    https://github.com/serge-sans-paille/gast/blob/master/setup.py
    https://github.com/serge-sans-paille/gast/blob/master/tox.ini
3. check changelogs
   https://github.com/serge-sans-paille/gast/blob/master/README.rst
   There are some changes mentioned regarding the way that ast.Name is replaced by ast.Param

   The AST used by GAST is the same as the one used in Python3.9, with the notable exception of ast.arg being replaced by an ast.Name with an ast.Param context.

   All other changes are bug fixes or updates

4. additional research
   there are no open issues mentioned in conda-forge
   https://github.com/conda-forge/gast-feedstock/issues

5. verify dev_url
6. verify doc_url
7. verify that pip is checked
8. verify that wheel is available
9. verify the test section

10. additional tests

    To start the tests, we will first make sure that the package `gast` builds properly and passes the initial build test
    We used the following commands for the initial testing `conda-build gast-feedstock --test`
    The results were the following `All tests passed`

Based on the results from the research, and our tests results we can conclude that it is safe to build gast
