### PR TITLE
gast 0.5.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "gast" %}
-{% set version = "0.5.2" %}
-{% set sha256 = "f81fcefa8b982624a31c9e4ec7761325a88a0eba60d36d1da90e47f8fe3c67f7" %}
+{% set version = "0.5.3" %}
+{% set sha256 = "cfbea25820e653af9c7d1807f659ce0a0a9c64f2439421a7bba4f0983f532dea" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ test:
     - gast
   requires:
     - pip
+    - python <3.10
   commands:
     - pip check
 


### PR DESCRIPTION
Update gast to 0.5.3

Version change: bump version number from 0.5.2 to 0.5.3
Concourse build: https://concourse.build.corp.continuum.io/teams/main/pipelines/auto-build-gast-0.5.3
Bug Tracker: new open issues https://github.com/serge-sans-paille/gast/issues
Upstream license:  License file:  https://github.com/serge-sans-paille/gast/blob/master/LICENSE
Upstream setup.py:  https://github.com/serge-sans-paille/gast/blob/0.5.3/setup.py

The package gast is mentioned inside the packages:
beniget | beniget-0.3.0 | pythran | tensorflow-base | tensorflow-gpu-base | tensorflow-probability |

Actions:
1. Fix python in test

Result:
- all-succeeded 