### PR TITLE
gast 0.5.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,44 +1,50 @@
 {% set name = "gast" %}
-{% set version = "0.6.0" %}
-{% set sha256 = "88fc5300d32c7ac6ca7b515310862f71e6fdf2c029bbec7c66c0f5dd47b6b1fb" %}
+{% set version = "0.5.4" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: 9c270fe5f4b130969b54174de7db4e764b09b4f7f67ccfc32480e29f78348d97
 
 build:
-  noarch: python
   number: 0
+  skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python 3.9
     - pip
+    - python
     - wheel
     - setuptools
   run:
-    - python >=3.9
+    - python
 
 test:
+  source_files:
+    - tests
   imports:
     - gast
   requires:
     - pip
+    - pytest
   commands:
     - pip check
+    # Number of tests fail on Python 3.13 with: AttributeError: type object 'arguments' has no attribute '_field_types'
+    # The typing.NamedTuple() class has deprecated the _field_types attribute in favor of the __annotations__ 
+    # attribute which carried the same information. Also, both attributes were converted from OrderedDict to a regular dict.
+    # https://github.com/python/cpython/issues/80501
+    - pytest -v tests  # [py<313]
 
 about:
   home: https://github.com/serge-sans-paille/gast
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  summary: "A generic AST to represent Python2 and Python3's Abstract Syntax Tree(AST)."
+  summary: A generic AST to represent Python2 and Python3's Abstract Syntax Tree(AST).
   description: |
     GAST provides a compatibility layer between the AST of various Python
     versions, as produced by ast.parse from the standard ast module.


### PR DESCRIPTION
gast 0.5.4 

**Destination channel:** default

### Links

- [PKG-9944](https://anaconda.atlassian.net/browse/PKG-9944)
- dev_url:        https://github.com/serge-sans-paille/gast/tree/0.5.4
- conda_forge:    https://github.com/conda-forge/gast-feedstock
- pypi:           https://pypi.org/project/gast/0.5.4
- pypi inspector: https://inspector.pypi.io/project/gast/0.5.4

### Explanation of changes:

- new version number

[PKG-9944]: https://anaconda.atlassian.net/browse/PKG-9944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ